### PR TITLE
Dummy-compile for unsupported target platforms too

### DIFF
--- a/source/syscalld/arch/syscall_x86.d
+++ b/source/syscalld/arch/syscall_x86.d
@@ -1,5 +1,6 @@
 module syscalld.arch.syscall_x86;
 
+version(Posix):
 version(D_InlineAsm_X86):
 @nogc:
 nothrow:

--- a/source/syscalld/arch/syscall_x86_64.d
+++ b/source/syscalld/arch/syscall_x86_64.d
@@ -1,5 +1,6 @@
 module syscalld.arch.syscall_x86_64;
 
+version(Posix):
 version(D_InlineAsm_X86_64):
 @nogc:
 nothrow:

--- a/source/syscalld/package.d
+++ b/source/syscalld/package.d
@@ -4,18 +4,18 @@ module syscalld;
 
 version(D_InlineAsm_X86_64)
 {
-    version(linux) import syscalld.os.linux_x86_64;
-    else version(OSX) import syscalld.os.osx_x86_64;
-    else version(FreeBSD) import syscalld.os.freebsd_x86_64;
+    version(linux) public import syscalld.os.linux_x86_64;
+    else version(OSX) public import syscalld.os.osx_x86_64;
+    else version(FreeBSD) public import syscalld.os.freebsd_x86_64;
     else static assert(false, "Not supported on your platform/architecuture.");
 
-    import syscalld.arch.syscall_x86_64;
+    public import syscalld.arch.syscall_x86_64;
 }
 else version(D_InlineAsm_X86)
 {
-    version(linux) import syscalld.os.linux_x86;
+    version(linux) public import syscalld.os.linux_x86;
     else static assert(false, "Not supported on your platform/architecuture.");
-    import syscalld.arch.syscall_x86;
+    public import syscalld.arch.syscall_x86;
 }
 else static assert(false, "Not supported on your platform/architecuture.");
 

--- a/source/syscalld/package.d
+++ b/source/syscalld/package.d
@@ -1,5 +1,6 @@
 module syscalld;
 
+version(Posix):
 @system:
 
 version(D_InlineAsm_X86_64)
@@ -7,19 +8,19 @@ version(D_InlineAsm_X86_64)
     version(linux) public import syscalld.os.linux_x86_64;
     else version(OSX) public import syscalld.os.osx_x86_64;
     else version(FreeBSD) public import syscalld.os.freebsd_x86_64;
-    else static assert(false, "Not supported on your platform/architecuture.");
 
     public import syscalld.arch.syscall_x86_64;
 }
 else version(D_InlineAsm_X86)
 {
     version(linux) public import syscalld.os.linux_x86;
-    else static assert(false, "Not supported on your platform/architecuture.");
     public import syscalld.arch.syscall_x86;
 }
-else static assert(false, "Not supported on your platform/architecuture.");
 
 unittest
 {
-    assert(syscall(GETPID) > 0);
+    static if (__traits(compiles, syscall(GETPID)))
+        assert(syscall(GETPID) > 0);
+    else
+        static assert(false, "Not supported on your platform/architecture.");
 }


### PR DESCRIPTION
As dub dependencies on syscall-d cannot be restricted to specific target platforms (without extra dub configs). So any dependent project built for e.g. Windows too and only actually using syscall-d on Linux needs syscall-d to dummy-compile on Windows etc. too.

`dub test` for non-supported Posix targets still results in a static assert error.